### PR TITLE
Tweak CSSTransitionGroup:componentDidMount()

### DIFF
--- a/src/csstransitiongroup.tsx
+++ b/src/csstransitiongroup.tsx
@@ -19,7 +19,9 @@ export class CSSTransitionGroup extends Component<CSSTransitionGroupProps, {}> {
     component: "div",
   };
   private mounted = false;
-  public componentDidMount = () => this.mounted = true;
+  public componentDidMount() {
+    this.mounted = true;
+  }
 
   public render() {
     const { transitionAppear, children, ...rest } = this.props as any;


### PR DESCRIPTION
This is a suggested fix for https://github.com/wikiwi/react-css-transition/issues/3.
Untested, but trivial.